### PR TITLE
fix: replace pnpx with pnpm dlx for cross-platform compatibility

### DIFF
--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:turbo && pnpm clean:node_modules",
     "ready": "tsc -b pre-build.tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "scripts": {
     "clean:bundle": "rimraf dist && turbo clean:bundle",
-    "clean:node_modules": "pnpx rimraf node_modules && pnpx turbo clean:node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules && pnpm dlx turbo clean:node_modules",
     "clean:turbo": "rimraf .turbo && turbo clean:turbo",
     "clean": "pnpm clean:bundle && pnpm clean:turbo && pnpm clean:node_modules",
     "clean:install": "pnpm clean:node_modules && pnpm install --frozen-lockfile",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b",

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -11,8 +11,8 @@
   "types": "index.mts",
   "main": "dist/index.mjs",
   "scripts": {
-    "clean:bundle": "rimraf dist && pnpx rimraf build",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:bundle": "rimraf dist && pnpm dlx rimraf build",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b && rollup --config dist/rollup.config.js",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -12,7 +12,7 @@
   "types": "index.mts",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b prepare-build.tsconfig.json && node --env-file=../../.env dist/lib/prepare_build.js && tsc -b",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,7 +14,7 @@
   "module": "dist/index.js",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b && tsc-alias -p tsconfig.json",

--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -9,8 +9,8 @@
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",
   "scripts": {
-    "clean:node_modules": "pnpx rimraf node_modules",
-    "clean:bundle": "pnpx rimraf dist",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
+    "clean:bundle": "pnpm dlx rimraf dist",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules",
     "ready": "tsc -b"
   },

--- a/packages/zipper/package.json
+++ b/packages/zipper/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "zip": "node --env-file=../../.env dist/index.mjs",

--- a/pages/content/package.json
+++ b/pages/content/package.json
@@ -9,7 +9,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:turbo && pnpm clean:node_modules",
     "build": "vite build",


### PR DESCRIPTION
This PR replaces all occurrences of 'pnpx' with 'pnpm dlx' across package.json files in the project. 

The pnpx command is being deprecated in favor of 'pnpm dlx', which is the recommended way to execute one-off commands with pnpm.

This change improves build reliability and cross-platform compatibility while maintaining the same functionality.

- Updated all clean scripts in package.json files
- Ensures consistent command usage across the monorepo
- Fixes build errors related to 'pnpx: command not found'