### PR TITLE
fix: prevent duplicate tool execution listeners for adapters

### DIFF
--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:turbo && pnpm clean:node_modules",
     "ready": "tsc -b pre-build.tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "scripts": {
     "clean:bundle": "rimraf dist && turbo clean:bundle",
-    "clean:node_modules": "pnpx rimraf node_modules && pnpx turbo clean:node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules && pnpm dlx turbo clean:node_modules",
     "clean:turbo": "rimraf .turbo && turbo clean:turbo",
     "clean": "pnpm clean:bundle && pnpm clean:turbo && pnpm clean:node_modules",
     "clean:install": "pnpm clean:node_modules && pnpm install --frozen-lockfile",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b",

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -11,8 +11,8 @@
   "types": "index.mts",
   "main": "dist/index.mjs",
   "scripts": {
-    "clean:bundle": "rimraf dist && pnpx rimraf build",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:bundle": "rimraf dist && pnpm dlx rimraf build",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b && rollup --config dist/rollup.config.js",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -12,7 +12,7 @@
   "types": "index.mts",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b prepare-build.tsconfig.json && node --env-file=../../.env dist/lib/prepare_build.js && tsc -b",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,7 +14,7 @@
   "module": "dist/index.js",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b && tsc-alias -p tsconfig.json",

--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -9,8 +9,8 @@
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",
   "scripts": {
-    "clean:node_modules": "pnpx rimraf node_modules",
-    "clean:bundle": "pnpx rimraf dist",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
+    "clean:bundle": "pnpm dlx rimraf dist",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules",
     "ready": "tsc -b"
   },

--- a/packages/zipper/package.json
+++ b/packages/zipper/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "zip": "node --env-file=../../.env dist/index.mjs",

--- a/pages/content/package.json
+++ b/pages/content/package.json
@@ -9,7 +9,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean:node_modules": "pnpx rimraf node_modules",
+    "clean:node_modules": "pnpm dlx rimraf node_modules",
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:turbo && pnpm clean:node_modules",
     "build": "vite build",

--- a/pages/content/src/adapters/adaptercomponents/common.ts
+++ b/pages/content/src/adapters/adaptercomponents/common.ts
@@ -406,7 +406,19 @@ export function handleAutoSubmit(adapterName: string): void {
 
 // --- Event Listener Setup ---
 
+// Track which adapters have already registered a listener
+const registeredToolExecutionListeners = new Set<string>();
+
 export function setupToolExecutionListener(stateManager: ToggleStateManager, adapterName: string): void {
+  // Guard against double subscription
+  if (registeredToolExecutionListeners.has(adapterName)) {
+    console.log(`[${adapterName}] Tool execution listener already registered, skipping.`);
+    return;
+  }
+
+  // Register this adapter
+  registeredToolExecutionListeners.add(adapterName);
+
   document.addEventListener('mcp:tool-execution-complete', (event: Event) => {
     const customEvent = event as CustomEvent;
     if (customEvent.detail) {


### PR DESCRIPTION
## Description
This PR adds a registration tracking mechanism to prevent the same adapter from registering multiple tool execution listeners. This fixes potential issues where duplicate event handlers could be created.

## Changes
- Added a Set to track which adapters have already registered listeners
- Added a guard in the setupToolExecutionListener function to skip registration if an adapter attempts to register more than once
- Added logging to help debug when duplicate registrations are attempted

## Fixes
Fixes #21

## Testing
Tested with multiple adapters to ensure:
- Adapters only register once even when the setup function is called multiple times
- Tool execution results are properly inserted without duplication
- Console logs show when duplicate registration attempts are skipped