### PR TITLE
fix: prevent duplicate tool execution listeners for adapters

### DIFF
--- a/pages/content/src/adapters/adaptercomponents/common.ts
+++ b/pages/content/src/adapters/adaptercomponents/common.ts
@@ -406,7 +406,19 @@ export function handleAutoSubmit(adapterName: string): void {
 
 // --- Event Listener Setup ---
 
+// Track which adapters have already registered a listener
+const registeredToolExecutionListeners = new Set<string>();
+
 export function setupToolExecutionListener(stateManager: ToggleStateManager, adapterName: string): void {
+  // Guard against double subscription
+  if (registeredToolExecutionListeners.has(adapterName)) {
+    console.log(`[${adapterName}] Tool execution listener already registered, skipping.`);
+    return;
+  }
+
+  // Register this adapter
+  registeredToolExecutionListeners.add(adapterName);
+
   document.addEventListener('mcp:tool-execution-complete', (event: Event) => {
     const customEvent = event as CustomEvent;
     if (customEvent.detail) {


### PR DESCRIPTION
## Description
This PR adds a registration tracking mechanism to prevent the same adapter from registering multiple tool execution listeners. This fixes potential issues where duplicate event handlers could be created.

## Changes
- Added a Set to track which adapters have already registered listeners
- Added a guard in the setupToolExecutionListener function to skip registration if an adapter attempts to register more than once
- Added logging to help debug when duplicate registration attempts are attempted

## Fixes
Fixes #21

## Testing
Tested with multiple adapters to ensure:
- Adapters only register once even when the setup function is called multiple times
- Tool execution results are properly inserted without duplication
- Console logs show when duplicate registration attempts are skipped