### PR TITLE
Fix CSP violations in browser extensions by downgrading MCP SDK

### DIFF
--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -22,7 +22,7 @@
     "@extension/env": "workspace:*",
     "@extension/shared": "workspace:*",
     "@extension/storage": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.19.1",
+    "@modelcontextprotocol/sdk": "1.19.1",
     "zod": "^4.3.5",
     "vite-plugin-node-polyfills": "^0.23.0",
     "webextension-polyfill": "^0.12.0",

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -22,7 +22,7 @@
     "@extension/env": "workspace:*",
     "@extension/shared": "workspace:*",
     "@extension/storage": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.19.1",
     "zod": "^4.3.5",
     "vite-plugin-node-polyfills": "^0.23.0",
     "webextension-polyfill": "^0.12.0",


### PR DESCRIPTION
Downgrade @modelcontextprotocol/sdk to 1.19.1 to avoid Zod/AJV code generation causing unsafe-eval CSP errors in Chrome extensions.